### PR TITLE
Wget -> Curl for ECS

### DIFF
--- a/ecs-cluster/files/threatstack.sh
+++ b/ecs-cluster/files/threatstack.sh
@@ -14,7 +14,7 @@ gpgcheck=1
 EOF
  
 # 2. Import PGP Key
-sudo wget https://app.threatstack.com/RPM-GPG-KEY-THREATSTACK -O /etc/pki/rpm-gpg/RPM-GPG-KEY-THREATSTACK
+sudo curl https://app.threatstack.com/RPM-GPG-KEY-THREATSTACK -o /etc/pki/rpm-gpg/RPM-GPG-KEY-THREATSTACK
 sudo rpm --import /etc/pki/rpm-gpg/RPM-GPG-KEY-THREATSTACK
  
 # 3. Install and configure the agent


### PR DESCRIPTION
Related to https://github.com/FoundryAI/hud-ai-app/issues/540

`wget` is unavailable on the ECS nodes, using `curl` instead