### PR TITLE
Update Bastion AMI to lasest Ubuntu 14.04 LTS.

### DIFF
--- a/bastion/main.tf
+++ b/bastion/main.tf
@@ -54,15 +54,8 @@ variable "zone_id" {
   description = "DNS Zone"
 }
 
-module "ami" {
-  source = "github.com/terraform-community-modules/tf_aws_ubuntu_ami/ebs"
-  region = "${var.region}"
-  distribution = "trusty"
-  instance_type = "${var.instance_type}"
-}
-
 resource "aws_instance" "bastion" {
-  ami = "${module.ami.ami_id}"
+  ami = "ami-0c9da1d34cb689bf6"
   source_dest_check = false
   instance_type = "${var.instance_type}"
   key_name = "${var.key_name}"


### PR DESCRIPTION
This PR does two things:

- Switches us from a dynamically AMI lookup service to a static hardcoded value.  (The dynamic service has been deprecated for 2 years and always returns an OS compiled in July 2017, so it was effectively static anyways).
- Updates us the latest build (December 2018) of Ubuntu Trusty 14.04 from Cannonical.  Should be low risk (same publisher, same OS). 


## AMI Details

**Existing**

> _ aws ec2 describe-images --output json --image-ids ami-2a0c313c_

```
{
    "Images": [
        {
            "VirtualizationType": "hvm", 
            "Name": "ubuntu/images/hvm/ubuntu-trusty-14.04-amd64-server-20170629", 
            "Hypervisor": "xen", 
            "SriovNetSupport": "simple", 
            "ImageId": "ami-2a0c313c", 
            "State": "available", 
            "BlockDeviceMappings": [
                {
                    "DeviceName": "/dev/sda1", 
                    "Ebs": {
                        "SnapshotId": "snap-0b645594d3f97f404", 
                        "DeleteOnTermination": true, 
                        "VolumeType": "standard", 
                        "VolumeSize": 8, 
                        "Encrypted": false
                    }
                }, 
                {
                    "DeviceName": "/dev/sdb", 
                    "VirtualName": "ephemeral0"
                }, 
                {
                    "DeviceName": "/dev/sdc", 
                    "VirtualName": "ephemeral1"
                }
            ], 
            "Architecture": "x86_64", 
            "ImageLocation": "099720109477/ubuntu/images/hvm/ubuntu-trusty-14.04-amd64-server-20170629", 
            "RootDeviceType": "ebs", 
            "OwnerId": "099720109477", 
            "RootDeviceName": "/dev/sda1", 
            "CreationDate": "2017-06-30T06:37:46.000Z", 
            "Public": true, 
            "ImageType": "machine"
        }
    ]
}
```

**Updating to:**

> _aws ec2 describe-images --output json --image-ids ami-0c9da1d34cb689bf6_

```
{
    "Images": [
        {
            "VirtualizationType": "hvm", 
            "Description": "Canonical, Ubuntu, 14.04 LTS, amd64 trusty image build on 2018-12-03", 
            "Hypervisor": "xen", 
            "EnaSupport": true, 
            "SriovNetSupport": "simple", 
            "ImageId": "ami-0c9da1d34cb689bf6", 
            "State": "available", 
            "BlockDeviceMappings": [
                {
                    "DeviceName": "/dev/sda1", 
                    "Ebs": {
                        "SnapshotId": "snap-03b71db504ab4d6b8", 
                        "DeleteOnTermination": true, 
                        "VolumeType": "standard", 
                        "VolumeSize": 8, 
                        "Encrypted": false
                    }
                }, 
                {
                    "DeviceName": "/dev/sdb", 
                    "VirtualName": "ephemeral0"
                }, 
                {
                    "DeviceName": "/dev/sdc", 
                    "VirtualName": "ephemeral1"
                }
            ], 
            "Architecture": "x86_64", 
            "ImageLocation": "099720109477/ubuntu/images/hvm/ubuntu-trusty-14.04-amd64-server-20181203", 
            "RootDeviceType": "ebs", 
            "OwnerId": "099720109477", 
            "RootDeviceName": "/dev/sda1", 
            "CreationDate": "2018-12-04T16:04:33.000Z", 
            "Public": true, 
            "ImageType": "machine", 
            "Name": "ubuntu/images/hvm/ubuntu-trusty-14.04-amd64-server-20181203"
        }
    ]
}
```